### PR TITLE
Add UI for adding permissions to tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,10 @@ gem 'tzinfo-data', '~> 1.2020.1'
 # https://github.com/thoughtbot/administrate
 gem 'administrate', '~> 0.14.0'
 
+# A plugin for nested has_many forms in Administrate
+# https://github.com/nickcharlton/administrate-field-nested_has_many
+gem 'administrate-field-nested_has_many', '~> 1.3.0'
+
 # Fixtures replacement with a straightforward definition syntax.
 # https://github.com/thoughtbot/factory_bot
 gem 'factory_bot', '~> 6.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
       momentjs-rails (~> 2.8)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
+    administrate-field-nested_has_many (1.3.0)
+      administrate (> 0.8, < 1)
+      cocoon (~> 1.2, >= 1.2.11)
     administrate_exportable (0.2.0)
       actionview (>= 5.2.2.1)
       administrate (>= 0.12.0)
@@ -84,6 +87,7 @@ GEM
       argon2-kdf (>= 0.1.1)
     builder (3.2.4)
     byebug (11.1.3)
+    cocoon (1.2.15)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
@@ -348,6 +352,7 @@ PLATFORMS
 
 DEPENDENCIES
   administrate (~> 0.14.0)
+  administrate-field-nested_has_many (~> 1.3.0)
   administrate_exportable (~> 0.2.0)
   blind_index
   byebug (~> 11.1.3)

--- a/app/controllers/ui/permissions_controller.rb
+++ b/app/controllers/ui/permissions_controller.rb
@@ -1,0 +1,8 @@
+class Ui::PermissionsController < Ui::ApplicationController
+  # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+  # for more information
+
+  def valid_action?(name, _resource = resource_class)
+    %w[index new create].include?(name.to_s)
+  end
+end

--- a/app/controllers/ui/permissions_controller.rb
+++ b/app/controllers/ui/permissions_controller.rb
@@ -1,8 +1,0 @@
-class Ui::PermissionsController < Ui::ApplicationController
-  # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-  # for more information
-
-  def valid_action?(name, _resource = resource_class)
-    %w[index new create].include?(name.to_s)
-  end
-end

--- a/app/controllers/ui/tokens_controller.rb
+++ b/app/controllers/ui/tokens_controller.rb
@@ -23,6 +23,6 @@ class Ui::TokensController < Ui::ApplicationController
   end
 
   def valid_action?(name, _resource = resource_class)
-    %w[index new create destroy].include?(name.to_s)
+    %w[index new create show destroy].include?(name.to_s)
   end
 end

--- a/app/controllers/ui/tokens_controller.rb
+++ b/app/controllers/ui/tokens_controller.rb
@@ -22,7 +22,10 @@ class Ui::TokensController < Ui::ApplicationController
     end
   end
 
-  def valid_action?(name, _resource = resource_class)
-    %w[index new create show destroy].include?(name.to_s)
+  def valid_action?(name, resource = resource_class)
+    case resource.to_s.downcase
+    when 'token' then %w[index new create show destroy].include?(name.to_s)
+    else false
+    end
   end
 end

--- a/app/dashboards/permission_dashboard.rb
+++ b/app/dashboards/permission_dashboard.rb
@@ -1,16 +1,6 @@
 require 'administrate/base_dashboard'
 
-class TokenDashboard < Administrate::BaseDashboard
-  class << self
-    def model
-      I18n.t('models.token.name', count: 1)
-    end
-
-    def resource_name(_opts = nil)
-      I18n.t('models.token.name', count: 2)
-    end
-  end
-
+class PermissionDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -18,15 +8,9 @@ class TokenDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    'name': Field::String,
-    'created_by': Field::BelongsTo.with_options(
-      class_name: 'User',
-      searchable: true,
-      searchable_fields: %w[first_name last_name]
-    ),
-    'created_at': Field::DateTime,
-    'token_one_time': Field::String,
-    'permissions': Field::NestedHasMany.with_options(skip: :subject)
+    'resource': Field::String,
+    'action': Field::String,
+    'columns': Field::String
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -35,25 +19,18 @@ class TokenDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    :name,
-    :created_by,
-    :created_at,
-    :permissions
-  ].freeze
-
-  # SHOW_PAGE_ATTRIBUTES
-  # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = [
-    :token_one_time,
-    :permissions
+    :resource,
+    :action,
+    :columns
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :name,
-    :permissions
+    :resource,
+    :action,
+    :columns
   ].freeze
 
   # COLLECTION_FILTERS
@@ -70,7 +47,7 @@ class TokenDashboard < Administrate::BaseDashboard
 
   # Overwrite this method to customize how training absence records are displayed
   # across all pages of the admin dashboard.
-  def display_resource(token)
-    token.name
+  def display_resource(permission)
+    permission.name
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,8 @@
 
 require('@rails/ujs').start()
 require('turbolinks').start()
+require('jquery')
+require('@nathanvda/cocoon')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -3,6 +3,7 @@ class Token < ApplicationRecord
 
   belongs_to :created_by, class_name: 'User'
   has_many :permissions, as: :subject, dependent: :destroy
+  accepts_nested_attributes_for :permissions, reject_if: :all_blank, allow_destroy: true
 
   validates :name, presence: true, uniqueness: true
   validates :token, presence: true

--- a/app/views/fields/string/_form.html.erb
+++ b/app/views/fields/string/_form.html.erb
@@ -15,7 +15,7 @@ By default, the input is a text field.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/String
 %>
 
-<% if errors.any? %>
+<% if defined?(errors) && errors.any? %>
   <div class="field-unit__label">
     <%= f.label field.attribute, class: "nhsuk-label", for: "input-with-error-message" %>
     <% errors.each do |error| %>
@@ -24,7 +24,7 @@ By default, the input is a text field.
       </span>
     <% end %>
   </div>
-  <% if hint %>
+  <% if defined?(hint) && hint %>
     <span class="nhsuk-hint" id="input-with-hint-text-hint">
       <%= hint %>
     </span>
@@ -36,7 +36,7 @@ By default, the input is a text field.
   <div class="field-unit__label">
     <%= f.label field.attribute, class: "nhsuk-label" %>
   </div>
-  <% if hint %>
+  <% if defined?(hint) && hint %>
     <span class="nhsuk-hint" id="input-with-hint-text-hint">
       <%= hint %>
     </span>

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -25,7 +25,7 @@ en:
         destroy: Are you sure? This token will be permanently deleted and any applications using it will no longer be able to access the API.
       instructions:
         title: API Token
-        content: This token gives complete access to ALL ESR data, including full confidential personal data. It must be kept secret and used with great care. This token can only be viewed once.
+        content: This token by itself grants full access to confidential, personally identifiable ESR data, according to the permissions selected below. It must be kept secret and used with great care. This token can only be viewed once.
       hints:
         name: "Example: HR Team - Business Analytics App"
       name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,6 @@ Rails.application.routes.draw do
     resources :training_absence_records do
       get :export, on: :collection
     end
-    resources :permissions, only: %i[index new create destroy]
     resources :tokens, only: %i[index new create show destroy]
     resources :users, only: %i[index show edit update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     resources :training_absence_records do
       get :export, on: :collection
     end
+    resources :permissions, only: %i[index new create destroy]
     resources :tokens, only: %i[index new create show destroy]
     resources :users, only: %i[index show edit update]
 

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,12 @@
 const { environment } = require('@rails/webpacker')
+const webpack = require('webpack');
+
+environment.plugins.append(
+  'Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery'
+  })
+);
 
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@nathanvda/cocoon": "^1.2.14",
     "@rails/ujs": "6.0.3",
     "@rails/webpacker": "5.2.1",
     "nhsuk-frontend": "^3.0.4",

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -9,6 +9,7 @@ describe Token, type: :model do
   it { should have_db_index(:name).unique }
   it { should belong_to(:created_by) }
   it { should have_many(:permissions).dependent(:destroy) }
+  it { should accept_nested_attributes_for(:tokens).allow_destroy(true) }
 
   describe '.verify' do
     let!(:token) { create(:token) }

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -9,7 +9,7 @@ describe Token, type: :model do
   it { should have_db_index(:name).unique }
   it { should belong_to(:created_by) }
   it { should have_many(:permissions).dependent(:destroy) }
-  it { should accept_nested_attributes_for(:tokens).allow_destroy(true) }
+  it { should accept_nested_attributes_for(:permissions).allow_destroy(true) }
 
   describe '.verify' do
     let!(:token) { create(:token) }

--- a/spec/requests/ui/tokens_controller_spec.rb
+++ b/spec/requests/ui/tokens_controller_spec.rb
@@ -89,7 +89,7 @@ describe Ui::TokensController, type: :request do
     let!(:token) { create(:token) }
 
     describe 'DELETE destroy' do
-      before { post ui_tokens_path, params: { token: { name: 'test' } } }
+      before { delete ui_token_path(token) }
 
       it { expect(response).to redirect_to(pages_home_path) }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -919,6 +919,13 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@nathanvda/cocoon@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@nathanvda/cocoon/-/cocoon-1.2.14.tgz#aaea910e4b9c0d28d5bdcb7f3743617db46b09af"
+  integrity sha512-WcEt2vVp50de2i7rkD4O+96O1iMtMIcTBNGPocrHfcmHDujKOngoLHFF8Ektgoh8PjwFAJMxx8WyGv0BtKTjxQ==
+  dependencies:
+    jquery "^3.3.1"
+
 "@npmcli/move-file@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz#de103070dac0f48ce49cf6693c23af59c0f70464"
@@ -4901,6 +4908,11 @@ jest-worker@^26.3.0:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jquery@^3.3.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-base64@^2.1.8:
   version "2.5.2"


### PR DESCRIPTION
Leaning on the Cocoon gem to provide the helpers for nested permissions on tokens. Not finished, the text fields need to be dropdowns, errors don't render, but it works if you enter the right strings.

<img width="999" alt="Screenshot 2020-09-18 at 17 31 24" src="https://user-images.githubusercontent.com/7175262/93622422-08403f80-f9d5-11ea-8a8c-fad64b8c9cd0.png">
<img width="1007" alt="Screenshot 2020-09-18 at 17 31 14" src="https://user-images.githubusercontent.com/7175262/93622430-0c6c5d00-f9d5-11ea-9850-10611fcca667.png">
