### PR TITLE
Cope with errors on Token permissions

### DIFF
--- a/app/controllers/ui/tokens_controller.rb
+++ b/app/controllers/ui/tokens_controller.rb
@@ -46,6 +46,16 @@ class Ui::TokensController < Ui::ApplicationController
     end
   end
 
+  def destroy
+    # delete rather than destroy to bypass the readonly? check on Token.
+    if requested_resource.delete
+      flash[:notice] = translate_with_resource('destroy.success')
+    else
+      flash[:error] = requested_resource.errors.full_messages.join('<br/>')
+    end
+    redirect_to action: :index
+  end
+
   def valid_action?(name, resource = resource_class)
     case resource.to_s.downcase
     when 'token' then %w[index new create show destroy].include?(name.to_s)

--- a/app/controllers/ui/tokens_controller.rb
+++ b/app/controllers/ui/tokens_controller.rb
@@ -37,6 +37,9 @@ class Ui::TokensController < Ui::ApplicationController
         notice: translate_with_resource('create.success')
       )
     else
+      @options = resource.permissions.map { |p|
+        PermissionHelper.column_options(resource: p.resource)
+      }
       render :new, locals: {
         page: Administrate::Page::Form.new(dashboard, resource)
       }

--- a/app/helpers/permission_helper.rb
+++ b/app/helpers/permission_helper.rb
@@ -8,8 +8,8 @@ module PermissionHelper
   def self.column_options_for_select2(resource:)
     return unless resource
 
-    column_options(resource: resource).map.with_index do |text, id|
-      { 'id' => id, 'text' => text }
+    column_options(resource: resource).map do |text|
+      { 'id' => text, 'text' => text }
     end
   end
 end

--- a/app/javascript/helpers/multiselect.js
+++ b/app/javascript/helpers/multiselect.js
@@ -6,11 +6,7 @@ $(document).on('cocoon:after-insert', (e, insertedItem, originalEvent) => {
 
   // Update permission#columns when permission#resource changed.
   $('.resource-select').on('change', (e) => {
-    // Temporary ID used to distinguish between multiple nested forms.
-    const id = e.target.id.split('_')[3]
-    const target = $('#token_permissions_attributes_' + id + '_columns')
-    const url = '/ui/tokens/new.json?resource=' + e.target.value
-    updateSelect(target, url)
+    updateSelect(e.target)
   });
 });
 
@@ -22,15 +18,15 @@ window.addEventListener('turbolinks:load', () => {
 
   // Update permission#columns when permission#resource changed.
   $('.resource-select').on('change', (e) => {
-    // Temporary ID used to distinguish between multiple nested forms.
-    const id = e.target.id.split('_')[3]
-    const target = $('#token_permissions_attributes_' + id + '_columns')
-    const url = '/ui/tokens/new.json?resource=' + e.target.value
-    updateSelect(target, url)
+    updateSelect(e.target)
   });
 });
 
-function updateSelect(target, url) {
+function updateSelect(element) {
+  // Temporary ID used to distinguish between multiple nested forms.
+  const id = element.id.split('_')[3]
+  const target = $('#token_permissions_attributes_' + id + '_columns')
+  const url = '/ui/tokens/new.json?resource=' + element.value
   // Fetch data.
   $.ajax({
     url: url,

--- a/app/javascript/helpers/multiselect.js
+++ b/app/javascript/helpers/multiselect.js
@@ -6,21 +6,11 @@ $(document).on('cocoon:after-insert', (e, insertedItem, originalEvent) => {
 
   // Update permission#columns when permission#resource changed.
   $('.resource-select').on('change', (e) => {
-    // Temporary ID used to distinguish between  multiple nested forms.
+    // Temporary ID used to distinguish between multiple nested forms.
     const id = e.target.id.split('_')[3]
+    const target = $('#token_permissions_attributes_' + id + '_columns')
     const url = '/ui/tokens/new.json?resource=' + e.target.value
-
-    // Fetch data.
-    $.ajax({
-      url: url,
-    }).done(function(response) {
-      // Find columns selector with the same ID, and update the column options.
-      $('#token_permissions_attributes_' + id + '_columns').empty().select2({
-        width: '100%',
-        data: response.column_options
-      })
-    });
-
+    updateSelect(target, url)
   });
 });
 
@@ -29,4 +19,26 @@ window.addEventListener('turbolinks:load', () => {
   $('.multiselect').select2({
     width: '100%'
   })
+
+  // Update permission#columns when permission#resource changed.
+  $('.resource-select').on('change', (e) => {
+    // Temporary ID used to distinguish between multiple nested forms.
+    const id = e.target.id.split('_')[3]
+    const target = $('#token_permissions_attributes_' + id + '_columns')
+    const url = '/ui/tokens/new.json?resource=' + e.target.value
+    updateSelect(target, url)
+  });
 });
+
+function updateSelect(target, url) {
+  // Fetch data.
+  $.ajax({
+    url: url,
+  }).done(function(response) {
+    // Find columns selector with the same ID, and update the column options.
+    target.empty().select2({
+      width: '100%',
+      data: response.column_options
+    })
+  });
+}

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -29,6 +29,10 @@ class Permission < ApplicationRecord
   validates :columns, presence: true
   validate :columns_match_resource
 
+  def columns
+    super&.split(',')
+  end
+
   def columns=(value)
     value = value.reject(&:empty?).join(',') if value.is_a?(Array)
 
@@ -38,7 +42,7 @@ class Permission < ApplicationRecord
   def columns_match_resource
     return if columns &&
               Permission::RESOURCES.include?(resource) &&
-              (columns.split(',') - resource.constantize.column_names).empty?
+              (columns - resource.constantize.column_names).empty?
 
     errors.add(:columns, I18n.t('models.permission.errors.column_not_found'))
   end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -33,6 +33,7 @@ class Permission < ApplicationRecord
     super&.split(',')
   end
 
+  # Columns are stored in the database as a comma-separated string.
   def columns=(value)
     value = value.reject(&:empty?).join(',') if value.is_a?(Array)
 

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -47,4 +47,8 @@ class Permission < ApplicationRecord
 
     errors.add(:columns, I18n.t('models.permission.errors.column_not_found'))
   end
+
+  def readonly?
+    persisted?
+  end
 end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -53,4 +53,8 @@ class Token < ApplicationRecord
 
     { token: token, permission: permission }
   end
+
+  def readonly?
+    persisted? && changes.keys != ['token_viewed_at']
+  end
 end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -2,7 +2,7 @@ class Token < ApplicationRecord
   include ActionView::Helpers::DateHelper
 
   belongs_to :created_by, class_name: 'User'
-  has_many :permissions, as: :subject, dependent: :destroy
+  has_many :permissions, as: :subject, dependent: :destroy, index_errors: true
 
   validates :name, presence: true, uniqueness: true
   validates :token, presence: true

--- a/app/resources/api/v1/absence_record_resource.rb
+++ b/app/resources/api/v1/absence_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::AbsenceRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::AbsenceRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/assignment_record_resource.rb
+++ b/app/resources/api/v1/assignment_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::AssignmentRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::AssignmentRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/competency_record_resource.rb
+++ b/app/resources/api/v1/competency_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::CompetencyRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::CompetencyRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/costing_record_resource.rb
+++ b/app/resources/api/v1/costing_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::CostingRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::CostingRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/disability_record_resource.rb
+++ b/app/resources/api/v1/disability_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::DisabilityRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::DisabilityRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/element_record_resource.rb
+++ b/app/resources/api/v1/element_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::ElementRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::ElementRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/location_record_resource.rb
+++ b/app/resources/api/v1/location_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::LocationRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::LocationRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/organisation_record_resource.rb
+++ b/app/resources/api/v1/organisation_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::OrganisationRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::OrganisationRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/person_eit_record_resource.rb
+++ b/app/resources/api/v1/person_eit_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::PersonEitRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::PersonEitRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/person_record_resource.rb
+++ b/app/resources/api/v1/person_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::PersonRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::PersonRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/position_eit_record_resource.rb
+++ b/app/resources/api/v1/position_eit_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::PositionEitRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::PositionEitRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/position_record_resource.rb
+++ b/app/resources/api/v1/position_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::PositionRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::PositionRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/qualification_record_resource.rb
+++ b/app/resources/api/v1/qualification_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::QualificationRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::QualificationRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/sit_record_resource.rb
+++ b/app/resources/api/v1/sit_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::SitRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::SitRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/resources/api/v1/training_absence_record_resource.rb
+++ b/app/resources/api/v1/training_absence_record_resource.rb
@@ -6,6 +6,6 @@ class Api::V1::TrainingAbsenceRecordResource < JSONAPI::Resource
   attributes(*ETL::Headers::TrainingAbsenceRecord.api_headers)
 
   def fetchable_fields
-    context[:credentials][:permission].columns.split(',').map(&:to_sym)
+    context[:credentials][:permission].columns.map(&:to_sym)
   end
 end

--- a/app/views/fields/multi_select/_form.html.erb
+++ b/app/views/fields/multi_select/_form.html.erb
@@ -12,7 +12,7 @@
       <%= f.select(
         field.attribute,
         options_from_collection_for_select(
-          field.selectable_options,
+          f.index.is_a?(Integer) ? @options[f.index] : field.selectable_options,
           :to_s,
           :to_s,
           field.data.presence,
@@ -34,7 +34,7 @@
       <%= f.select(
         field.attribute,
         options_from_collection_for_select(
-          field.selectable_options,
+          f.index.is_a?(Integer) ? @options[f.index] : field.selectable_options,
           :to_s,
           :to_s,
           field.data.presence,

--- a/app/views/fields/multi_select/_index.html.erb
+++ b/app/views/fields/multi_select/_index.html.erb
@@ -1,3 +1,3 @@
-<% field.to_param.split(',').each do |item| %>
+<% field.to_param.each do |item| %>
   <li><%= item %></li>
 <% end %>

--- a/app/views/fields/multi_select/_show.html.erb
+++ b/app/views/fields/multi_select/_show.html.erb
@@ -1,3 +1,3 @@
-<% field.to_param.split(',').each do |item| %>
+<% field.to_param.each do |item| %>
   <li><%= item %></li>
 <% end %>

--- a/app/views/fields/nested_has_many/_form.html.erb
+++ b/app/views/fields/nested_has_many/_form.html.erb
@@ -20,9 +20,9 @@
           f: nested_form,
           field: field,
           errors: errors.to_hash.select { |k, v|
-            k.to_s.include?(field.association_name)
+            k.to_s.include?("#{field.association_name}[#{nested_form.index}]")
           }.transform_keys { |k|
-            k.to_s.gsub("#{field.association_name}.", '').to_sym
+            k.to_s.gsub("#{field.association_name}[#{nested_form.index}].", '').to_sym
           }
         },
       ) %>

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -42,6 +42,7 @@ en:
     permission:
       errors:
         column_not_found: don't all exist in resource
+        uniqueness: cannot create multiple permissions for action '%{action}' on resource '%{resource}'
     user:
       errors:
         cant_deactivate: can't deactivate the only active user

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -1,4 +1,11 @@
 en:
+  activerecord:
+    errors:
+      models:
+        token:
+          attributes:
+            permissions:
+              invalid: are invalid
   administrate:
     actions:
       destroy: Delete

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -38,7 +38,11 @@ workers ENV.fetch('WEB_CONCURRENCY') { 2 }
 #
 # Under most situations you will not have to tweak this value, which is why it
 # is coded into the config rather than being an environment variable.
-worker_timeout 30
+if ENV.fetch('RAILS_ENV') == 'development'
+  worker_timeout 3600
+else
+  worker_timeout 30
+end
 
 # The path to the puma binary without any arguments.
 restart_command 'puma'

--- a/spec/api/v1/absence_records/get_spec.rb
+++ b/spec/api/v1/absence_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'SitRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::SitRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::SitRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::AbsenceRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::AbsenceRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/absence_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(absence_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if absence_record.send(key).is_a?(Time)
                       expect(absence_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/absence_records/index_spec.rb
+++ b/spec/api/v1/absence_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'SitRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::SitRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::SitRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::AbsenceRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::AbsenceRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/absence_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = AbsenceRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/assignment_records/get_spec.rb
+++ b/spec/api/v1/assignment_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::AssignmentRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::AssignmentRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::AssignmentRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::AssignmentRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/assignment_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(assignment_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if assignment_record.send(key).is_a?(Time)
                       expect(assignment_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/assignment_records/index_spec.rb
+++ b/spec/api/v1/assignment_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::AssignmentRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::AssignmentRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::AssignmentRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::AssignmentRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/assignment_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = AssignmentRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/competency_records/get_spec.rb
+++ b/spec/api/v1/competency_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::CompetencyRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::CompetencyRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::CompetencyRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::CompetencyRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/competency_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(competency_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if competency_record.send(key).is_a?(Time)
                       expect(competency_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/competency_records/index_spec.rb
+++ b/spec/api/v1/competency_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::CompetencyRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::CompetencyRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::CompetencyRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::CompetencyRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/competency_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = CompetencyRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/costing_records/get_spec.rb
+++ b/spec/api/v1/costing_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::CostingRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::CostingRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::CostingRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::CostingRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/costing_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(costing_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if costing_record.send(key).is_a?(Time)
                       expect(costing_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/costing_records/index_spec.rb
+++ b/spec/api/v1/costing_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::CostingRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::CostingRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::CostingRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::CostingRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/costing_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = CostingRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/disability_records/get_spec.rb
+++ b/spec/api/v1/disability_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::DisabilityRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::DisabilityRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::DisabilityRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::DisabilityRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/disability_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(disability_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if disability_record.send(key).is_a?(Time)
                       expect(disability_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/disability_records/index_spec.rb
+++ b/spec/api/v1/disability_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::DisabilityRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::DisabilityRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::DisabilityRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::DisabilityRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/disability_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = DisabilityRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/element_records/get_spec.rb
+++ b/spec/api/v1/element_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::ElementRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::ElementRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::ElementRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::ElementRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/element_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(element_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if element_record.send(key).is_a?(Time)
                       expect(element_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/element_records/index_spec.rb
+++ b/spec/api/v1/element_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::ElementRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::ElementRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::ElementRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::ElementRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/element_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = ElementRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/location_records/get_spec.rb
+++ b/spec/api/v1/location_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::LocationRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::LocationRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::LocationRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::LocationRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/location_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(location_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if location_record.send(key).is_a?(Time)
                       expect(location_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/location_records/index_spec.rb
+++ b/spec/api/v1/location_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::LocationRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::LocationRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::LocationRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::LocationRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/location_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = LocationRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/organisation_records/get_spec.rb
+++ b/spec/api/v1/organisation_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::OrganisationRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::OrganisationRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::OrganisationRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::OrganisationRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/organisation_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(organisation_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if organisation_record.send(key).is_a?(Time)
                       expect(organisation_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/organisation_records/index_spec.rb
+++ b/spec/api/v1/organisation_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::OrganisationRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::OrganisationRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::OrganisationRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::OrganisationRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/organisation_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = OrganisationRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/person_eit_records/get_spec.rb
+++ b/spec/api/v1/person_eit_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PersonEitRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PersonEitRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PersonEitRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PersonEitRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/person_eit_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(person_eit_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if person_eit_record.send(key).is_a?(Time)
                       expect(person_eit_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/person_eit_records/index_spec.rb
+++ b/spec/api/v1/person_eit_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PersonEitRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PersonEitRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PersonEitRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PersonEitRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/person_eit_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = PersonEitRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/person_records/get_spec.rb
+++ b/spec/api/v1/person_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PersonRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PersonRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PersonRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PersonRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/person_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(person_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if person_record.send(key).is_a?(Time)
                       expect(person_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/person_records/index_spec.rb
+++ b/spec/api/v1/person_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PersonRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PersonRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PersonRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PersonRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/person_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = PersonRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/position_eit_records/get_spec.rb
+++ b/spec/api/v1/position_eit_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PositionEitRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PositionEitRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PositionEitRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PositionEitRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/position_eit_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(position_eit_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if position_eit_record.send(key).is_a?(Time)
                       expect(position_eit_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/position_eit_records/index_spec.rb
+++ b/spec/api/v1/position_eit_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PositionEitRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PositionEitRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PositionEitRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PositionEitRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/position_eit_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = PositionEitRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/position_records/get_spec.rb
+++ b/spec/api/v1/position_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PositionRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PositionRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PositionRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PositionRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/position_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(position_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if position_record.send(key).is_a?(Time)
                       expect(position_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/position_records/index_spec.rb
+++ b/spec/api/v1/position_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::PositionRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::PositionRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::PositionRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::PositionRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/position_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = PositionRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/qualification_records/get_spec.rb
+++ b/spec/api/v1/qualification_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::QualificationRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::QualificationRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::QualificationRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::QualificationRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/qualification_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(qualification_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if qualification_record.send(key).is_a?(Time)
                       expect(qualification_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/qualification_records/index_spec.rb
+++ b/spec/api/v1/qualification_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::QualificationRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::QualificationRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::QualificationRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::QualificationRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/qualification_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = QualificationRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/sit_records/get_spec.rb
+++ b/spec/api/v1/sit_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::SitRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::SitRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::SitRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::SitRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/sit_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(sit_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if sit_record.send(key).is_a?(Time)
                       expect(sit_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/sit_records/index_spec.rb
+++ b/spec/api/v1/sit_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::SitRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::SitRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::SitRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::SitRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/sit_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = SitRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/api/v1/training_absence_records/get_spec.rb
+++ b/spec/api/v1/training_absence_records/get_spec.rb
@@ -34,13 +34,13 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'show' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -75,14 +75,14 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/training_absence_record_response'
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     expect(training_absence_record.send(key).to_s).to eq(value.to_s)
                   end
@@ -97,7 +97,7 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
 
               describe 'attributes match database values' do
                 run_test! do
-                  expect(response_data['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if training_absence_record.send(key).is_a?(Time)
                       expect(training_absence_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)

--- a/spec/api/v1/training_absence_records/index_spec.rb
+++ b/spec/api/v1/training_absence_records/index_spec.rb
@@ -37,13 +37,13 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
           )
         end
         let!(:confirmed_user) { create(:confirmed_user) }
-        let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers.join(',') }
+        let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers }
         let(:Authorization) { "Bearer #{token.token}" }
 
         context 'with a permission with the wrong resource' do
           let(:resource) { 'AbsenceRecord' }
           let(:action) { 'index' }
-          let(:columns) { ETL::Headers::AbsenceRecord.api_headers.join(',') }
+          let(:columns) { ETL::Headers::AbsenceRecord.api_headers }
 
           response '403', 'Error: Forbidden' do
             schema '$ref' => '#/definitions/error_403'
@@ -78,7 +78,7 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
           end
 
           context 'with a subset of columns' do
-            let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers[0..4].join(',') }
+            let(:columns) { ETL::Headers::TrainingAbsenceRecord.api_headers[0..4] }
 
             response '200', 'successful' do
               schema '$ref' => '#/definitions/training_absence_records_response'
@@ -86,7 +86,7 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
               describe 'attributes match database values' do
                 run_test! do
                   expect(response_data.count).to eq(2)
-                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns.split(','))
+                  expect(response_data.first['attributes'].map(&:first)).to match_array(columns)
                   database_record = TrainingAbsenceRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     expect(database_record.send(key).to_s).to eq(value.to_s)

--- a/spec/helpers/permission_helper_spec.rb
+++ b/spec/helpers/permission_helper_spec.rb
@@ -29,8 +29,8 @@ describe PermissionHelper do
         expect(
           PermissionHelper.column_options_for_select2(resource: resource)
         ).to eq(
-          ETL::Headers::AbsenceRecord.api_headers.map.with_index do |text, id|
-            { 'id' => id, 'text' => text }
+          ETL::Headers::AbsenceRecord.api_headers.map do |text|
+            { 'id' => text, 'text' => text }
           end
         )
       end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -32,15 +32,12 @@ describe Permission, type: :model do
   end
 
   context 'with a persisted token' do
-    context 'updating the permission' do
+    describe 'updating the permission' do
       it 'fails; tokens should be immutable' do
-        expect {
+        expect do
           subject.update(columns: PermissionHelper.column_options(resource: subject.resource))
-        }.to raise_error(ActiveRecord::ReadOnlyRecord)
+        end.to raise_error(ActiveRecord::ReadOnlyRecord)
       end
     end
-  end
-
-  describe 'deleting the permission' do
   end
 end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -30,4 +30,17 @@ describe Permission, type: :model do
       )
     end
   end
+
+  context 'with a persisted token' do
+    context 'updating the permission' do
+      it 'fails; tokens should be immutable' do
+        expect {
+          subject.update(columns: PermissionHelper.column_options(resource: subject.resource))
+        }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      end
+    end
+  end
+
+  describe 'deleting the permission' do
+  end
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -12,6 +12,27 @@ describe Token, type: :model do
   it { should validate_presence_of(:token) }
   it { should accept_nested_attributes_for(:permissions).allow_destroy(true) }
 
+  context 'with a persisted token' do
+    subject { create(:token) }
+
+    context 'when adding a new permission' do
+      let(:permission) do
+        build(
+          :permission,
+          resource: Permission::RESOURCES.last,
+          action: Permission::ACTIONS.last,
+          columns: 'Person ID'
+        )
+      end
+
+      before { subject.permissions << permission }
+
+      it 'fails; tokens should be immutable' do
+        expect { subject.save! }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      end
+    end
+  end
+
   describe '.verify' do
     let!(:token) { create(:token, permissions: [permission]) }
     let(:permission) do

--- a/spec/requests/ui/tokens_controller_spec.rb
+++ b/spec/requests/ui/tokens_controller_spec.rb
@@ -130,7 +130,7 @@ describe Ui::TokensController, type: :request do
                      ]
                    }
                  }
-          }.not_to change { Token.count }
+          }.not_to(change { Token.count })
         end
       end
     end

--- a/spec/requests/ui/tokens_controller_spec.rb
+++ b/spec/requests/ui/tokens_controller_spec.rb
@@ -119,7 +119,7 @@ describe Ui::TokensController, type: :request do
 
       context 'with 2 identical permissions' do
         it 'is invalid' do
-          expect {
+          expect do
             post ui_tokens_path,
                  params: {
                    token: {
@@ -130,7 +130,7 @@ describe Ui::TokensController, type: :request do
                      ]
                    }
                  }
-          }.not_to(change { Token.count })
+          end.not_to(change { Token.count })
         end
       end
     end

--- a/spec/requests/ui/tokens_controller_spec.rb
+++ b/spec/requests/ui/tokens_controller_spec.rb
@@ -114,7 +114,7 @@ describe Ui::TokensController, type: :request do
         expect(Token.last.name).to eq(name)
         expect(Token.last.permissions.first.resource).to eq(permission_resource)
         expect(Token.last.permissions.first.action).to eq(permission_action)
-        expect(Token.last.permissions.first.columns).to eq(permission_columns.reject(&:empty?).join(','))
+        expect(Token.last.permissions.first.columns).to eq(permission_columns.reject(&:empty?))
       end
 
       context 'with 2 identical permissions' do

--- a/spec/requests/ui/tokens_controller_spec.rb
+++ b/spec/requests/ui/tokens_controller_spec.rb
@@ -88,6 +88,13 @@ describe Ui::TokensController, type: :request do
         'Absence Type'
       ]
     }
+    let(:permission_attributes) {
+      {
+        resource: permission_resource,
+        action: permission_action,
+        columns: permission_columns
+      }
+    }
 
     before { sign_in create(:confirmed_user) }
 
@@ -99,11 +106,7 @@ describe Ui::TokensController, type: :request do
             token: {
               name: name,
               permissions_attributes: [
-                {
-                  resource: permission_resource,
-                  action: permission_action,
-                  columns: permission_columns
-                }
+                permission_attributes
               ]
             }
           }
@@ -112,6 +115,23 @@ describe Ui::TokensController, type: :request do
         expect(Token.last.permissions.first.resource).to eq(permission_resource)
         expect(Token.last.permissions.first.action).to eq(permission_action)
         expect(Token.last.permissions.first.columns).to eq(permission_columns.reject(&:empty?).join(','))
+      end
+
+      context 'with 2 identical permissions' do
+        it 'is invalid' do
+          expect {
+            post ui_tokens_path,
+                 params: {
+                   token: {
+                     name: name,
+                     permissions_attributes: [
+                       permission_attributes,
+                       permission_attributes
+                     ]
+                   }
+                 }
+          }.not_to change { Token.count }
+        end
       end
     end
   end


### PR DESCRIPTION
- Render errors correctly on Permission#columns
- Return Permission#columns as an array by default (they're stored as a string in the DB)
- Increase byebug timeout for easier debugging