### PR TITLE
Approve BSD 0-Clause license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2020-10-14
+
+### Changed
+
+- Approve the [BSD 0-Clause](https://tldrlegal.com/license/bsd-0-clause-license), a permissive license which is used by the Yarn dependency Snyk.
+
 ## [0.4.0] - 2020-10-14
 
 ### Added

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,3 +1,3 @@
 module EsrApi
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,33 +1,33 @@
 ---
 - - :permit
   - MIT
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:39:34.586091300 Z
 - - :permit
   - CC0-1.0
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:48:06.204956200 Z
 - - :permit
   - LGPL
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:48:10.773637900 Z
 - - :permit
   - ISC
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:48:14.132040800 Z
 - - :permit
   - New
   - &1
-    :who: 
-    :why: 
+    :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:52:11.592132100 Z
 - - :permit
@@ -35,110 +35,110 @@
   - *1
 - - :permit
   - New BSD
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:53:26.920364800 Z
 - - :permit
   - Apache 2.0
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:55:57.801800900 Z
 - - :permit
   - BSD-3-Clause OR MIT
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 13:57:59.332783700 Z
 - - :permit
   - MIT*
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:00:49.981838800 Z
 - - :permit
   - "(MIT OR Apache-2.0)"
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:00:55.560534300 Z
 - - :permit
   - Simplified BSD
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:01:52.584750100 Z
 - - :permit
   - CC-BY-4.0
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:02:37.677036900 Z
 - - :permit
   - BSD*
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:06:40.174789000 Z
 - - :permit
   - "(BSD-3-Clause OR GPL-2.0)"
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:10:16.498856200 Z
 - - :permit
   - Zlib
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:11:45.350816800 Z
 - - :permit
   - "(MIT AND Zlib)"
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:12:14.180869800 Z
 - - :permit
   - "(WTFPL OR MIT)"
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:19:44.108048700 Z
 - - :permit
   - WTFPL
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:19:49.288718100 Z
 - - :permit
   - MIT, Apache License v2.0
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:19:59.077988000 Z
 - - :permit
   - "(MIT AND BSD-3-Clause)"
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:20:49.944267400 Z
 - - :permit
   - CC-BY-3.0
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:22:02.915435700 Z
 - - :permit
   - Unlicense
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:24:06.731133300 Z
 - - :permit
   - ruby
-  - :who: 
-    :why: 
+  - :who:
+    :why:
     :versions: []
     :when: 2020-06-16 14:24:28.121908900 Z
 - - :approve
@@ -148,3 +148,9 @@
       also MIT licensed.
     :versions: []
     :when: 2020-06-16 16:40:45.378926400 Z
+- - :permit
+  - BSD Zero Clause License
+  - :who:
+    :why:
+    :versions: []
+    :when: 2020-10-14 18:36:50.534108700 Z


### PR DESCRIPTION
- Approve the [BSD 0-Clause](https://tldrlegal.com/license/bsd-0-clause-license), a permissive license which is used by the Yarn dependency Snyk.
