### PR TITLE
Handle race condition in import jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2020-11-24
+
+### Changed
+
+- Handle race condition in import jobs.
+
 ## [0.6.0] - 2020-11-20
 
 ### Added

--- a/app/errors/too_many_retries_error.rb
+++ b/app/errors/too_many_retries_error.rb
@@ -1,0 +1,1 @@
+class TooManyRetriesError < StandardError; end

--- a/app/services/etl/destinations/active_record.rb
+++ b/app/services/etl/destinations/active_record.rb
@@ -16,27 +16,30 @@ class ETL::Destinations::ActiveRecord
       end
     else
       row = row.merge({ 'created_at' => Time.current, 'updated_at' => Time.current })
-      create(row)
+      upsert(row)
     end
   end
 
-  def create(row)
+  def upsert(row)
+    # Upsert instead of create here to avoid race condition where a record is
+    # created and updated at almost the same file; the record can be written after
+    # #existing_record checks, but before the below is called.
     case row['Record Type']
-    when 'ABA' then ::AbsenceRecord.insert_all!([row.except('Record Type')])
-    when 'ASA' then ::AssignmentRecord.insert_all!([row.except('Record Type')])
-    when 'COA' then ::CostingRecord.insert_all!([row.except('Record Type')])
-    when 'CMA' then ::CompetencyRecord.insert_all!([row.except('Record Type')])
-    when 'DTA' then ::DisabilityRecord.insert_all!([row.except('Record Type')])
-    when 'ELA' then ::ElementRecord.insert_all!([row.except('Record Type')])
-    when 'ETA' then ::PersonEitRecord.insert_all!([row.except('Record Type')])
-    when 'LCA' then ::LocationRecord.insert_all!([row.except('Record Type')])
-    when 'ORA' then ::OrganisationRecord.insert_all!([row.except('Record Type')])
-    when 'PRA' then ::PersonRecord.insert_all!([row.except('Record Type')])
-    when 'PIA' then ::PositionEitRecord.insert_all!([row.except('Record Type')])
-    when 'POA' then ::PositionRecord.insert_all!([row.except('Record Type')])
-    when 'QLA' then ::QualificationRecord.insert_all!([row.except('Record Type')])
-    when 'STA' then ::SitRecord.insert_all!([row.except('Record Type')])
-    when 'TRA' then ::TrainingAbsenceRecord.insert_all!([row.except('Record Type')])
+    when 'ABA' then ::AbsenceRecord.upsert(row.except('Record Type'))
+    when 'ASA' then ::AssignmentRecord.upsert(row.except('Record Type'))
+    when 'COA' then ::CostingRecord.upsert(row.except('Record Type'))
+    when 'CMA' then ::CompetencyRecord.upsert(row.except('Record Type'))
+    when 'DTA' then ::DisabilityRecord.upsert(row.except('Record Type'))
+    when 'ELA' then ::ElementRecord.upsert(row.except('Record Type'))
+    when 'ETA' then ::PersonEitRecord.upsert(row.except('Record Type'))
+    when 'LCA' then ::LocationRecord.upsert(row.except('Record Type'))
+    when 'ORA' then ::OrganisationRecord.upsert(row.except('Record Type'))
+    when 'PRA' then ::PersonRecord.upsert(row.except('Record Type'))
+    when 'PIA' then ::PositionEitRecord.upsert(row.except('Record Type'))
+    when 'POA' then ::PositionRecord.upsert(row.except('Record Type'))
+    when 'QLA' then ::QualificationRecord.upsert(row.except('Record Type'))
+    when 'STA' then ::SitRecord.upsert(row.except('Record Type'))
+    when 'TRA' then ::TrainingAbsenceRecord.upsert(row.except('Record Type'))
     end
   end
 

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,3 +1,3 @@
 module EsrApi
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: []
+  resolved_paths: []
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
- Handle race condition where an update job can be handled as a create job, even though the record already exists in the DB.
- Update webpacker syntax