### PR TITLE
Fix specs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,8 @@ module EsrApi # rubocop:disable Style/ClassAndModuleChildren
 
     # Set up logging to be the same in all environments but control the level
     # through an environment variable.
-    config.log_level = ENV['LOG_LEVEL']
+    config.log_level = ENV['LOG_LEVEL'] if ENV['LOG_LEVEL']
+
 
     # Log to STDOUT because Docker expects all processes to log here. You could
     # then redirect logs to a third party service on your own such as systemd,
@@ -35,6 +36,8 @@ module EsrApi # rubocop:disable Style/ClassAndModuleChildren
       url: "redis://:#{ENV['REDIS_PASSWORD']}@redis:#{ENV['REDIS_PORT']}/0",
       namespace: ENV['REDIS_CACHE_NAMESPACE']
     }
+
+    config.active_record.belongs_to_required_by_default = false
 
     # Set Sidekiq as the back-end for Active Job.
     config.active_job.queue_adapter = :sidekiq

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,6 @@ Rails.application.configure do
 
   # Generate swagger docs.
   config.swagger_dry_run = false
+
+  config.time_zone = 'London'
 end

--- a/spec/api/v1/absence_records/get_spec.rb
+++ b/spec/api/v1/absence_records/get_spec.rb
@@ -122,7 +122,7 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if absence_record.send(key).is_a?(Time)
-                      expect(absence_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(absence_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(absence_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/absence_records/index_spec.rb
+++ b/spec/api/v1/absence_records/index_spec.rb
@@ -129,7 +129,7 @@ describe 'Api::V1::AbsenceRecordResource', type: :request, swagger_doc: 'v1/swag
                   database_record = AbsenceRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/assignment_records/get_spec.rb
+++ b/spec/api/v1/assignment_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if assignment_record.send(key).is_a?(Time)
-                      expect(assignment_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(assignment_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(assignment_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/assignment_records/index_spec.rb
+++ b/spec/api/v1/assignment_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::AssignmentRecordResource', type: :request, swagger_doc: 'v1/s
                   database_record = AssignmentRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/competence_definition_records/get_spec.rb
+++ b/spec/api/v1/competence_definition_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::CompetenceDefinitionRecordResource', type: :request, swagger_
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if competence_definition_record.send(key).is_a?(Time)
-                      expect(competence_definition_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(competence_definition_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(competence_definition_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/competence_definition_records/index_spec.rb
+++ b/spec/api/v1/competence_definition_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::CompetenceDefinitionRecordResource', type: :request, swagger_
                   database_record = CompetenceDefinitionRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/competency_records/get_spec.rb
+++ b/spec/api/v1/competency_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if competency_record.send(key).is_a?(Time)
-                      expect(competency_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(competency_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(competency_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/competency_records/index_spec.rb
+++ b/spec/api/v1/competency_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::CompetencyRecordResource', type: :request, swagger_doc: 'v1/s
                   database_record = CompetencyRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/costing_records/get_spec.rb
+++ b/spec/api/v1/costing_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if costing_record.send(key).is_a?(Time)
-                      expect(costing_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(costing_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(costing_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/costing_records/index_spec.rb
+++ b/spec/api/v1/costing_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::CostingRecordResource', type: :request, swagger_doc: 'v1/swag
                   database_record = CostingRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/disability_records/get_spec.rb
+++ b/spec/api/v1/disability_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if disability_record.send(key).is_a?(Time)
-                      expect(disability_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(disability_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(disability_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/disability_records/index_spec.rb
+++ b/spec/api/v1/disability_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::DisabilityRecordResource', type: :request, swagger_doc: 'v1/s
                   database_record = DisabilityRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/element_records/get_spec.rb
+++ b/spec/api/v1/element_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if element_record.send(key).is_a?(Time)
-                      expect(element_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(element_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(element_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/element_records/index_spec.rb
+++ b/spec/api/v1/element_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::ElementRecordResource', type: :request, swagger_doc: 'v1/swag
                   database_record = ElementRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/location_records/get_spec.rb
+++ b/spec/api/v1/location_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if location_record.send(key).is_a?(Time)
-                      expect(location_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(location_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(location_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/location_records/index_spec.rb
+++ b/spec/api/v1/location_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::LocationRecordResource', type: :request, swagger_doc: 'v1/swa
                   database_record = LocationRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/organisation_records/get_spec.rb
+++ b/spec/api/v1/organisation_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if organisation_record.send(key).is_a?(Time)
-                      expect(organisation_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(organisation_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(organisation_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/organisation_records/index_spec.rb
+++ b/spec/api/v1/organisation_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::OrganisationRecordResource', type: :request, swagger_doc: 'v1
                   database_record = OrganisationRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/person_eit_records/get_spec.rb
+++ b/spec/api/v1/person_eit_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if person_eit_record.send(key).is_a?(Time)
-                      expect(person_eit_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(person_eit_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(person_eit_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/person_eit_records/index_spec.rb
+++ b/spec/api/v1/person_eit_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::PersonEitRecordResource', type: :request, swagger_doc: 'v1/sw
                   database_record = PersonEitRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/person_records/get_spec.rb
+++ b/spec/api/v1/person_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if person_record.send(key).is_a?(Time)
-                      expect(person_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(person_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(person_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/person_records/index_spec.rb
+++ b/spec/api/v1/person_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::PersonRecordResource', type: :request, swagger_doc: 'v1/swagg
                   database_record = PersonRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/position_eit_records/get_spec.rb
+++ b/spec/api/v1/position_eit_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if position_eit_record.send(key).is_a?(Time)
-                      expect(position_eit_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(position_eit_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(position_eit_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/position_eit_records/index_spec.rb
+++ b/spec/api/v1/position_eit_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::PositionEitRecordResource', type: :request, swagger_doc: 'v1/
                   database_record = PositionEitRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/position_records/get_spec.rb
+++ b/spec/api/v1/position_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if position_record.send(key).is_a?(Time)
-                      expect(position_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(position_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(position_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/position_records/index_spec.rb
+++ b/spec/api/v1/position_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::PositionRecordResource', type: :request, swagger_doc: 'v1/swa
                   database_record = PositionRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/qualification_records/get_spec.rb
+++ b/spec/api/v1/qualification_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if qualification_record.send(key).is_a?(Time)
-                      expect(qualification_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(qualification_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(qualification_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/qualification_records/index_spec.rb
+++ b/spec/api/v1/qualification_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::QualificationRecordResource', type: :request, swagger_doc: 'v
                   database_record = QualificationRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/sit_records/get_spec.rb
+++ b/spec/api/v1/sit_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if sit_record.send(key).is_a?(Time)
-                      expect(sit_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(sit_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(sit_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/sit_records/index_spec.rb
+++ b/spec/api/v1/sit_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::SitRecordResource', type: :request, swagger_doc: 'v1/swagger.
                   database_record = SitRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/training_absence_records/get_spec.rb
+++ b/spec/api/v1/training_absence_records/get_spec.rb
@@ -100,7 +100,7 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
                   expect(response_data['attributes'].map(&:first)).to match_array(columns)
                   response_data['attributes'].each do |key, value|
                     if training_absence_record.send(key).is_a?(Time)
-                      expect(training_absence_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(training_absence_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(training_absence_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/api/v1/training_absence_records/index_spec.rb
+++ b/spec/api/v1/training_absence_records/index_spec.rb
@@ -106,7 +106,7 @@ describe 'Api::V1::TrainingAbsenceRecordResource', type: :request, swagger_doc: 
                   database_record = TrainingAbsenceRecord.find(response_data.first['id'])
                   response_data.first['attributes'].each do |key, value|
                     if database_record.send(key).is_a?(Time)
-                      expect(database_record.send(key).strftime('%Y-%m-%dT%H:%M:%S.000Z')).to eq(value.to_s)
+                      expect(database_record.send(key).iso8601(3)).to eq(value.to_s)
                     else
                       expect(database_record.send(key).to_s).to eq(value.to_s)
                     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
   config.include ActiveJob::TestHelper, type: :job
 
   config.around(:example) do |example|


### PR DESCRIPTION
* Specs rely on the test environment time zone being set to London, so set it.
* Model specs fail because default validation on belongs_to is to always require associated object, turn this off.